### PR TITLE
Current temperature sensor

### DIFF
--- a/ac.yaml.example
+++ b/ac.yaml.example
@@ -50,3 +50,6 @@ climate:
     #   name: Panasonic AC NanoeX Switch
     # mild_dry_switch:
     #   name: Panasonic AC Mild Dry Switch
+
+    # Useful when the ac does not report a current temperature (CZ-TACG1 only)
+    # current_temperature_sensor: temperature_sensor_id

--- a/components/panasonic_ac/climate.py
+++ b/components/panasonic_ac/climate.py
@@ -49,23 +49,24 @@ HORIZONTAL_SWING_OPTIONS = [
 
 VERTICAL_SWING_OPTIONS = ["auto", "up", "up_center", "center", "down_center", "down"]
 
+SWITCH_SCHEMA = switch.SWITCH_SCHEMA.extend(cv.COMPONENT_SCHEMA).extend(
+    {cv.GenerateID(): cv.declare_id(PanasonicACSwitch)}
+)
+SELECT_SCHEMA = select.SELECT_SCHEMA.extend(
+    {cv.GenerateID(CONF_ID): cv.declare_id(PanasonicACSelect)}
+)
+
 SCHEMA = climate.CLIMATE_SCHEMA.extend(
     {
-        cv.Optional(CONF_HORIZONTAL_SWING_SELECT): select.SELECT_SCHEMA.extend(
-            {cv.GenerateID(CONF_ID): cv.declare_id(PanasonicACSelect)}
-        ),
-        cv.Optional(CONF_VERTICAL_SWING_SELECT): select.SELECT_SCHEMA.extend(
-            {cv.GenerateID(CONF_ID): cv.declare_id(PanasonicACSelect)}
-        ),
+        cv.Optional(CONF_HORIZONTAL_SWING_SELECT): SELECT_SCHEMA,
+        cv.Optional(CONF_VERTICAL_SWING_SELECT): SELECT_SCHEMA,
         cv.Optional(CONF_OUTSIDE_TEMPERATURE): sensor.sensor_schema(
             unit_of_measurement=UNIT_CELSIUS,
             accuracy_decimals=0,
             device_class=DEVICE_CLASS_TEMPERATURE,
             state_class=STATE_CLASS_MEASUREMENT,
         ),
-        cv.Optional(CONF_NANOEX_SWITCH): switch.SWITCH_SCHEMA.extend(
-            cv.COMPONENT_SCHEMA
-        ).extend({cv.GenerateID(): cv.declare_id(PanasonicACSwitch)}),
+        cv.Optional(CONF_NANOEX_SWITCH): SWITCH_SCHEMA,
     }
 ).extend(uart.UART_DEVICE_SCHEMA)
 
@@ -79,12 +80,8 @@ CONFIG_SCHEMA = cv.typed_schema(
         CONF_CNT: SCHEMA.extend(
             {
                 cv.GenerateID(): cv.declare_id(PanasonicACCNT),
-                cv.Optional(CONF_ECO_SWITCH): switch.SWITCH_SCHEMA.extend(
-                    cv.COMPONENT_SCHEMA
-                ).extend({cv.GenerateID(): cv.declare_id(PanasonicACSwitch)}),
-                cv.Optional(CONF_MILD_DRY_SWITCH): switch.SWITCH_SCHEMA.extend(
-                    cv.COMPONENT_SCHEMA
-                ).extend({cv.GenerateID(): cv.declare_id(PanasonicACSwitch)}),
+                cv.Optional(CONF_ECO_SWITCH): SWITCH_SCHEMA,
+                cv.Optional(CONF_MILD_DRY_SWITCH): SWITCH_SCHEMA,
             }
         ),
     }

--- a/components/panasonic_ac/climate.py
+++ b/components/panasonic_ac/climate.py
@@ -68,7 +68,6 @@ SCHEMA = climate.CLIMATE_SCHEMA.extend(
             state_class=STATE_CLASS_MEASUREMENT,
         ),
         cv.Optional(CONF_NANOEX_SWITCH): SWITCH_SCHEMA,
-        cv.Optional(CONF_CURRENT_TEMPERATURE_SENSOR): cv.use_id(sensor.Sensor),
     }
 ).extend(uart.UART_DEVICE_SCHEMA)
 
@@ -84,6 +83,7 @@ CONFIG_SCHEMA = cv.typed_schema(
                 cv.GenerateID(): cv.declare_id(PanasonicACCNT),
                 cv.Optional(CONF_ECO_SWITCH): SWITCH_SCHEMA,
                 cv.Optional(CONF_MILD_DRY_SWITCH): SWITCH_SCHEMA,
+                cv.Optional(CONF_CURRENT_TEMPERATURE_SENSOR): cv.use_id(sensor.Sensor),
             }
         ),
     }

--- a/components/panasonic_ac/climate.py
+++ b/components/panasonic_ac/climate.py
@@ -31,6 +31,7 @@ PanasonicACSelect = panasonic_ac_ns.class_(
 CONF_HORIZONTAL_SWING_SELECT = "horizontal_swing_select"
 CONF_VERTICAL_SWING_SELECT = "vertical_swing_select"
 CONF_OUTSIDE_TEMPERATURE = "outside_temperature"
+CONF_CURRENT_TEMPERATURE_SENSOR = "current_temperature_sensor"
 CONF_NANOEX_SWITCH = "nanoex_switch"
 CONF_ECO_SWITCH = "eco_switch"
 CONF_MILD_DRY_SWITCH = "mild_dry_switch"
@@ -67,6 +68,7 @@ SCHEMA = climate.CLIMATE_SCHEMA.extend(
             state_class=STATE_CLASS_MEASUREMENT,
         ),
         cv.Optional(CONF_NANOEX_SWITCH): SWITCH_SCHEMA,
+        cv.Optional(CONF_CURRENT_TEMPERATURE_SENSOR): cv.use_id(sensor.Sensor),
     }
 ).extend(uart.UART_DEVICE_SCHEMA)
 
@@ -117,3 +119,7 @@ async def to_code(config):
             await cg.register_component(a_switch, conf)
             await switch.register_switch(a_switch, conf)
             cg.add(getattr(var, f"set_{s}")(a_switch))
+
+    if CONF_CURRENT_TEMPERATURE_SENSOR in config:
+        sens = await cg.get_variable(config[CONF_CURRENT_TEMPERATURE_SENSOR])
+        cg.add(var.set_current_temperature_sensor(sens))

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -154,6 +154,16 @@ void PanasonicAC::set_outside_temperature_sensor(sensor::Sensor *outside_tempera
   this->outside_temperature_sensor_ = outside_temperature_sensor;
 }
 
+void PanasonicAC::set_current_temperature_sensor(sensor::Sensor *current_temperature_sensor)
+{
+  this->current_temperature_sensor_ = current_temperature_sensor;
+  this->current_temperature_sensor_->add_on_state_callback([this](float state)
+                                                           {
+                                                             this->current_temperature = state;
+                                                             this->publish_state();
+                                                           });
+}
+
 void PanasonicAC::set_vertical_swing_select(select::Select *vertical_swing_select) {
   this->vertical_swing_select_ = vertical_swing_select;
   this->vertical_swing_select_->add_on_state_callback([this](const std::string &value) {

--- a/components/panasonic_ac/esppac.h
+++ b/components/panasonic_ac/esppac.h
@@ -39,6 +39,8 @@ class PanasonicAC : public Component, public uart::UARTDevice, public climate::C
   void set_eco_switch(switch_::Switch *eco_switch);
   void set_mild_dry_switch(switch_::Switch *mild_dry_switch);
 
+  void set_current_temperature_sensor(sensor::Sensor *current_temperature_sensor);
+
   void setup() override;
   void loop() override;
 
@@ -49,6 +51,7 @@ class PanasonicAC : public Component, public uart::UARTDevice, public climate::C
   switch_::Switch *nanoex_switch_ = nullptr;              // Switch to toggle nanoeX on/off
   switch_::Switch *eco_switch_ = nullptr;                 // Switch to toggle eco mode on/off
   switch_::Switch *mild_dry_switch_ = nullptr;            // Switch to toggle mild dry mode on/off
+  sensor::Sensor *current_temperature_sensor_ = nullptr;  // Sensor to use for current temperature where AC does not report
 
   std::string vertical_swing_state_;
   std::string horizontal_swing_state_;

--- a/components/panasonic_ac/esppac_cnt.cpp
+++ b/components/panasonic_ac/esppac_cnt.cpp
@@ -161,8 +161,11 @@ void PanasonicACCNT::set_data(bool set) {
 
   if (set)  // Also set current and outside temperature
   {
-    this->update_current_temperature((int8_t) this->rx_buffer_[18]);
-    this->update_outside_temperature((int8_t) this->rx_buffer_[19]);
+    if (this->current_temperature_sensor_ == nullptr)
+      this->update_current_temperature((int8_t)this->rx_buffer_[18]);
+
+    if (this->outside_temperature_sensor_ != nullptr)
+      this->update_outside_temperature((int8_t)this->rx_buffer_[19]);
   }
 
   if (verticalSwing == "auto" && horizontalSwing == "auto")


### PR DESCRIPTION
Allow configuring an external sensor to use as climate current temperature.
This can be useful when the unit does not report the current temperature.

This is only added for cztacg1/cn-cnt as I do not know if the wlan/dnskp11 would not send the temperature.

I can add this to both if there is a chance the wlan might not send the temperature?

My unit only sends `0x80, 0x80` for both indoor/outdoor temperature bytes