### PR TITLE
Fix power consumption

### DIFF
--- a/components/panasonic_ac/esppac_cnt.cpp
+++ b/components/panasonic_ac/esppac_cnt.cpp
@@ -464,8 +464,8 @@ bool PanasonicACCNT::determine_mild_dry(uint8_t value) {
   }
 }
 
-uint16_t PanasonicACCNT::determine_power_consumption(uint8_t byte_28, uint8_t multiplier, uint8_t offset) {
-  return (uint16_t)(byte_28 + (multiplier * 255)) - offset;
+uint16_t PanasonicACCNT::determine_power_consumption(uint8_t byte_28, uint8_t byte_29, uint8_t offset) {
+  return (uint16_t)(byte_28 + (byte_29 * 256)) - offset;
 }
 
 /*


### PR DESCRIPTION
It seems extremly unlikely that you need to multiply with 255 for second byte for power consumtion. it is more likely that you 2 bytes are used to represent the power conmsumtion. I which case byte 29 needs to be multiplied with 256.

This would be a neglectable change in the power (1 watt per 256 what), but the code makes more sense then :)