### PR TITLE
Add vertical swing mode swing (constantly moving up/down)

### DIFF
--- a/components/panasonic_ac/climate.py
+++ b/components/panasonic_ac/climate.py
@@ -52,7 +52,7 @@ HORIZONTAL_SWING_OPTIONS = [
 ]
 
 
-VERTICAL_SWING_OPTIONS = ["moving", "auto", "up", "up_center", "center", "down_center", "down"]
+VERTICAL_SWING_OPTIONS = ["swing", "auto", "up", "up_center", "center", "down_center", "down"]
 
 SWITCH_SCHEMA = switch.SWITCH_SCHEMA.extend(cv.COMPONENT_SCHEMA).extend(
     {cv.GenerateID(): cv.declare_id(PanasonicACSwitch)}

--- a/components/panasonic_ac/climate.py
+++ b/components/panasonic_ac/climate.py
@@ -52,7 +52,7 @@ HORIZONTAL_SWING_OPTIONS = [
 ]
 
 
-VERTICAL_SWING_OPTIONS = ["auto", "up", "up_center", "center", "down_center", "down"]
+VERTICAL_SWING_OPTIONS = ["moving", "auto", "up", "up_center", "center", "down_center", "down"]
 
 SWITCH_SCHEMA = switch.SWITCH_SCHEMA.extend(cv.COMPONENT_SCHEMA).extend(
     {cv.GenerateID(): cv.declare_id(PanasonicACSwitch)}

--- a/components/panasonic_ac/esppac_cnt.cpp
+++ b/components/panasonic_ac/esppac_cnt.cpp
@@ -371,7 +371,7 @@ std::string PanasonicACCNT::determine_vertical_swing(uint8_t swing) {
     case 0x00:
       return "unsupported";
     default:
-      ESP_LOGW(TAG, "Received unknown vertical swing mode");
+      ESP_LOGW(TAG, "Received unknown vertical swing mode: 0x%02X", nib);
       return "Unknown";
   }
 }

--- a/components/panasonic_ac/esppac_cnt.cpp
+++ b/components/panasonic_ac/esppac_cnt.cpp
@@ -356,6 +356,8 @@ std::string PanasonicACCNT::determine_vertical_swing(uint8_t swing) {
   uint8_t nib = (swing >> 4) & 0x0F;  // Left nib for vertical swing
 
   switch (nib) {
+    case 0x0E:
+      return "moving";
     case 0x0F:
       return "auto";
     case 0x01:
@@ -488,6 +490,8 @@ void PanasonicACCNT::on_vertical_swing_change(const std::string &swing) {
     this->data[4] = (this->data[4] & 0x0F) + 0x20;
   else if (swing == "up")
     this->data[4] = (this->data[4] & 0x0F) + 0x10;
+  else if (swing == "moving")
+    this->data[4] = (this->data[4] & 0x0F) + 0xE0;
   else if (swing == "auto")
     this->data[4] = (this->data[4] & 0x0F) + 0xF0;
   else {

--- a/components/panasonic_ac/esppac_cnt.cpp
+++ b/components/panasonic_ac/esppac_cnt.cpp
@@ -357,7 +357,7 @@ std::string PanasonicACCNT::determine_vertical_swing(uint8_t swing) {
 
   switch (nib) {
     case 0x0E:
-      return "moving";
+      return "swing";
     case 0x0F:
       return "auto";
     case 0x01:
@@ -490,7 +490,7 @@ void PanasonicACCNT::on_vertical_swing_change(const std::string &swing) {
     this->data[4] = (this->data[4] & 0x0F) + 0x20;
   else if (swing == "up")
     this->data[4] = (this->data[4] & 0x0F) + 0x10;
-  else if (swing == "moving")
+  else if (swing == "swing")
     this->data[4] = (this->data[4] & 0x0F) + 0xE0;
   else if (swing == "auto")
     this->data[4] = (this->data[4] & 0x0F) + 0xF0;


### PR DESCRIPTION
My Panasonic HZ25XKE has a vertical swing mode where the flap constantly swings up/down (like in auto, except that in auto "Once the temperature is achieved, the horizontal flap is fixed at upper position"). I get an error in the log when this mode is selected:
```
[23:25:30][V][panasonic_ac:245]: TX: 70.0A.00.00.00.00.00.00.00.00.00.00.86 (13)
[23:25:30][V][panasonic_ac:247]: RX: 70.20.44.30.80.A0.ED.40.00.40.00.00.4C.32.00.00.00.00.17.01.1F.18.01.FF.80.80.FF.80.61.01.09.80.18.83.9D (35)
[23:25:30][W][panasonic_ac.cz_tacg1:374]: Received unknown vertical swing mode
[23:25:30][E][select:018]: 'Panasonic Vertical Swing Mode': invalid state for publish_state(): Unknown
```

The value of this mode is found by logging to be 0x0E.
