### PR TITLE
Simple Command buffering for CN-CNT

### DIFF
--- a/components/panasonic_ac/esppac_cnt.cpp
+++ b/components/panasonic_ac/esppac_cnt.cpp
@@ -31,7 +31,7 @@ void PanasonicACCNT::loop() {
 
     this->rx_buffer_.clear();  // Reset buffer
   }
-
+  handle_cmd();
   handle_poll();  // Handle sending poll packets
 }
 
@@ -44,6 +44,7 @@ void PanasonicACCNT::control(const climate::ClimateCall &call) {
     return;
 
   if (this->cmd.empty()) {
+    ESP_LOGV(TAG, "Copying data to cmd");
     this->cmd = this->data;
   }
 
@@ -492,6 +493,7 @@ void PanasonicACCNT::on_vertical_swing_change(const std::string &swing) {
   ESP_LOGD(TAG, "Setting vertical swing position");
 
   if (this->cmd.empty()) {
+    ESP_LOGV(TAG, "Copying data to cmd");
     this->cmd = this->data;
   }
 
@@ -523,6 +525,7 @@ void PanasonicACCNT::on_horizontal_swing_change(const std::string &swing) {
   ESP_LOGD(TAG, "Setting horizontal swing position");
 
   if (this->cmd.empty()) {
+    ESP_LOGV(TAG, "Copying data to cmd");
     this->cmd = this->data;
   }
 
@@ -550,6 +553,7 @@ void PanasonicACCNT::on_nanoex_change(bool state) {
     return;
 
   if (this->cmd.empty()) {
+    ESP_LOGV(TAG, "Copying data to cmd");
     this->cmd = this->data;
   }
 
@@ -569,6 +573,7 @@ void PanasonicACCNT::on_eco_change(bool state) {
     return;
 
   if (this->cmd.empty()) {
+    ESP_LOGV(TAG, "Copying data to cmd");
     this->cmd = this->data;
   }
 
@@ -588,6 +593,7 @@ void PanasonicACCNT::on_econavi_change(bool state) {
     return;
 
   if (this->cmd.empty()) {
+    ESP_LOGV(TAG, "Copying data to cmd");
     this->cmd = this->data;
   }
 
@@ -608,6 +614,7 @@ void PanasonicACCNT::on_mild_dry_change(bool state) {
     return;
 
   if (this->cmd.empty()) {
+    ESP_LOGV(TAG, "Copying data to cmd");
     this->cmd = this->data;
   }
 

--- a/components/panasonic_ac/esppac_cnt.h
+++ b/components/panasonic_ac/esppac_cnt.h
@@ -10,6 +10,7 @@ static const uint8_t CTRL_HEADER = 0xF0;  // The header for control frames
 static const uint8_t POLL_HEADER = 0x70;  // The header for the poll command
 
 static const int POLL_INTERVAL = 5000;  // The interval at which to poll the AC
+static const int CMD_INTERVAL = 250;  // The interval at which to send commands
 
 enum class ACState {
   Initializing,  // Before first query response is receive
@@ -35,7 +36,10 @@ class PanasonicACCNT : public PanasonicAC {
 
   // uint8_t data[10];
   std::vector<uint8_t> data = std::vector<uint8_t>(10);  // Stores the data received from the AC
+  std::vector<uint8_t> cmd;  // Used to build next command
+
   void handle_poll();
+  void handle_cmd();
 
   void set_data(bool set);
 


### PR DESCRIPTION
Using CN-CNT together with MQTT-only did not play well together: MQTT makes everything a separate command and together with using HA schedules, resulted in multiple commands arriving in very short succession (e.g. mode heat + target temp 20).
So I implemented a very simple command buffer: commands are now only sent from the loop with a minimum 250ms interval. 
For this, I keep a separate command buffer: whenever a command arrives, I check if this buffer has data, in which case I add the new command to the buffer, else I first copy the last data buffer received. In the loop, if there is a command, I send it, then clear the command buffer.
Seems enough to fix my problems.