### PR TITLE
Add support for newer Ethera devices

### DIFF
--- a/components/panasonic_ac/esppac.h
+++ b/components/panasonic_ac/esppac.h
@@ -13,8 +13,8 @@ namespace panasonic_ac {
 
 static const char *const VERSION = "2.4.0";
 
-static const uint8_t BUFFER_SIZE = 128;  // The maximum size of a single packet (both receive and transmit)
-static const uint8_t READ_TIMEOUT = 20;  // The maximum time to wait before considering a packet complete
+static const uint8_t BUFFER_SIZE = 240;  // The maximum size of a single packet (both receive and transmit)
+static const uint8_t READ_TIMEOUT = 240;  // The maximum time to wait before considering a packet complete
 
 static const uint8_t MIN_TEMPERATURE = 16;     // Minimum temperature as reported by Panasonic app
 static const uint8_t MAX_TEMPERATURE = 30;     // Maximum temperature as supported by Panasonic app

--- a/components/panasonic_ac/esppac_wlan.cpp
+++ b/components/panasonic_ac/esppac_wlan.cpp
@@ -646,6 +646,10 @@ void PanasonicACWLAN::send_set_command() {
     packet[12 + (i * 4) + 3] =
         0x00;  // Unknown, either 0x00 or 0x01 or 0x02; overwritten by checksum on last key value pair
   }
+  
+  if (packet[12] == 0x31) {
+  packet[11] = 0x02;
+  }
 
   send_packet(packet, CommandType::Normal);
   this->set_queue_index_ = 0;

--- a/components/panasonic_ac/esppac_wlan.cpp
+++ b/components/panasonic_ac/esppac_wlan.cpp
@@ -597,8 +597,8 @@ void PanasonicACWLAN::handle_handshake_packet() {
   } else if (this->rx_buffer_[2] == 0x10 && this->rx_buffer_[3] == 0x88)  // Answer for handshake 13
   {
     // Ignore
-    ESP_LOGD(TAG, "Ignoring handshake [13/16]");
-    this->state_ = ACState::Initializing;  // restart init
+    ESP_LOGD(TAG, "Ignoring handshake [13/16] and Restarting Initialization");
+    this->state_ = ACState::Initializing;  // Restart Initialization, otherwise hangs here. Likely to succeed on 2nd attempt.
   } else if (this->rx_buffer_[2] == 0x01 &&
              this->rx_buffer_[3] == 0x09)  // First unsolicited packet from AC containing rx counter
   {

--- a/components/panasonic_ac/esppac_wlan.cpp
+++ b/components/panasonic_ac/esppac_wlan.cpp
@@ -598,6 +598,7 @@ void PanasonicACWLAN::handle_handshake_packet() {
   {
     // Ignore
     ESP_LOGD(TAG, "Ignoring handshake [13/16]");
+    this->state_ = ACState::Initializing;  // restart init
   } else if (this->rx_buffer_[2] == 0x01 &&
              this->rx_buffer_[3] == 0x09)  // First unsolicited packet from AC containing rx counter
   {

--- a/components/panasonic_ac/esppac_wlan.h
+++ b/components/panasonic_ac/esppac_wlan.h
@@ -13,7 +13,7 @@ static const int INIT_END_TIMEOUT = 10000;   // Time to wait for last handshake 
 static const int FIRST_POLL_TIMEOUT = 650;   // Time to wait before requesting the first poll
 static const int POLL_INTERVAL = 30000;      // The interval at which to poll the AC
 static const int RESPONSE_TIMEOUT = 600;     // The timeout after which we expect a response to our last command
-static const int INIT_FAIL_TIMEOUT = 30000;  // The timeout after which the initialization is considered failed
+static const int INIT_FAIL_TIMEOUT = 300000;  // The timeout after which the initialization is considered failed
 
 enum class ACState {
   Initializing,     // Before first handshake packet is sent

--- a/components/panasonic_ac/esppac_wlan.h
+++ b/components/panasonic_ac/esppac_wlan.h
@@ -9,11 +9,11 @@ namespace WLAN {
 static const uint8_t HEADER = 0x5A;  // The header of the protocol, every packet starts with this
 
 static const int INIT_TIMEOUT = 10000;       // Time to wait before initializing after boot
-static const int INIT_END_TIMEOUT = 10000;   // Time to wait for last handshake packet
+static const int INIT_END_TIMEOUT = 20000;   // Time to wait for last handshake packet
 static const int FIRST_POLL_TIMEOUT = 650;   // Time to wait before requesting the first poll
 static const int POLL_INTERVAL = 30000;      // The interval at which to poll the AC
 static const int RESPONSE_TIMEOUT = 600;     // The timeout after which we expect a response to our last command
-static const int INIT_FAIL_TIMEOUT = 30000;  // The timeout after which the initialization is considered failed
+static const int INIT_FAIL_TIMEOUT = 60000;  // The timeout after which the initialization is considered failed
 
 enum class ACState {
   Initializing,     // Before first handshake packet is sent

--- a/components/panasonic_ac/esppac_wlan.h
+++ b/components/panasonic_ac/esppac_wlan.h
@@ -13,7 +13,7 @@ static const int INIT_END_TIMEOUT = 10000;   // Time to wait for last handshake 
 static const int FIRST_POLL_TIMEOUT = 650;   // Time to wait before requesting the first poll
 static const int POLL_INTERVAL = 30000;      // The interval at which to poll the AC
 static const int RESPONSE_TIMEOUT = 600;     // The timeout after which we expect a response to our last command
-static const int INIT_FAIL_TIMEOUT = 300000;  // The timeout after which the initialization is considered failed
+static const int INIT_FAIL_TIMEOUT = 30000;  // The timeout after which the initialization is considered failed
 
 enum class ACState {
   Initializing,     // Before first handshake packet is sent


### PR DESCRIPTION
This pull adds support for newer Ethera devices.

Major changes required are larger buffer size (and timeout for that) since the packets are now >128 bytes big.
Also on temp change it requires field 4 to be set to 02 instead of 00 of the packet. I implented this with a quite dirty hack and
if there is a better way to do it - please change it. 
Also changed INIT_END_TIMEOUT and INIT_FAIL_TIMEOUT due to initialization restarts requiring this (or component will fail before restarted init could complete). Needed this since from time to time it would stop at handshake 13 and just hang there.
Which this pull it will directly restart initialization if it encounters the handshake 13 and in my tests it always success the init after that.

All of these changes should have no impact on other generations of panasonic ACs besides the temp change field "hack". I dont have access to different panasonic equipment so i cant test this and see if others are fine with the change, too. 
Maybe some special config flag for the YAML should be added to implent the 02 field for ethera devices to avoid bricking support for other devices.