### PR TITLE
Reduce status update rate to change only

### DIFF
--- a/components/panasonic_ac/climate.py
+++ b/components/panasonic_ac/climate.py
@@ -146,5 +146,11 @@ async def to_code(config):
         cg.add(var.set_current_temperature_sensor(sens))
 
     if CONF_CURRENT_POWER_CONSUMPTION in config:
+        log.info('current')
         sens = await sensor.new_sensor(config[CONF_CURRENT_POWER_CONSUMPTION])
         cg.add(var.set_current_power_consumption_sensor(sens))
+
+    if CONF_TODAY_POWER_CONSUMPTION in config:
+        log.info('today')
+        sens = await sensor.new_sensor(config[CONF_TODAY_POWER_CONSUMPTION])
+        cg.add(var.set_today_power_consumption_sensor(sens))

--- a/components/panasonic_ac/climate.py
+++ b/components/panasonic_ac/climate.py
@@ -146,11 +146,9 @@ async def to_code(config):
         cg.add(var.set_current_temperature_sensor(sens))
 
     if CONF_CURRENT_POWER_CONSUMPTION in config:
-        logger.warning('current')
         sens = await sensor.new_sensor(config[CONF_CURRENT_POWER_CONSUMPTION])
         cg.add(var.set_current_power_consumption_sensor(sens))
 
     if CONF_TODAY_POWER_CONSUMPTION in config:
-        logger.warning('today')
         sens = await sensor.new_sensor(config[CONF_TODAY_POWER_CONSUMPTION])
         cg.add(var.set_today_power_consumption_sensor(sens))

--- a/components/panasonic_ac/climate.py
+++ b/components/panasonic_ac/climate.py
@@ -146,11 +146,11 @@ async def to_code(config):
         cg.add(var.set_current_temperature_sensor(sens))
 
     if CONF_CURRENT_POWER_CONSUMPTION in config:
-        log.info('current')
+        logger.warning('current')
         sens = await sensor.new_sensor(config[CONF_CURRENT_POWER_CONSUMPTION])
         cg.add(var.set_current_power_consumption_sensor(sens))
 
     if CONF_TODAY_POWER_CONSUMPTION in config:
-        log.info('today')
+        logger.warning('today')
         sens = await sensor.new_sensor(config[CONF_TODAY_POWER_CONSUMPTION])
         cg.add(var.set_today_power_consumption_sensor(sens))

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -31,7 +31,7 @@ climate::ClimateTraits PanasonicAC::traits() {
   return traits;
 }
 
-extern double saved_today;
+extern double esphome::panasonic_ac::saved_today;
 
 void PanasonicAC::setup() {
   // Initialize times
@@ -41,7 +41,7 @@ void PanasonicAC::setup() {
 
   ESP_LOGI(TAG, "Panasonic AC component v%s starting...", VERSION);
 
-  this->today_consumption = saved_today;
+  this->today_consumption = esphome::panasonic_ac::saved_today;
 }
 
 time_t day_seconds() {

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -169,20 +169,23 @@ climate::ClimateAction PanasonicAC::determine_action() {
 void PanasonicAC::update_current_power_consumption(int16_t power) {
   if (this->current_power_consumption_sensor_ != nullptr) {
     if (this->current_power_consumption_sensor_->state != power) {
-      this->current_power_consumption_sensor_->publish_state(power);  // Set current power consumption
+      this->current_power_consumption_sensor_->publish_state(power); // Set current power consumption
     }
     if (this->today_power_consumption_sensor_ != nullptr) {
       double oldConsumption = std::round(this->today_consumption * 1000.0) / 1000.0;
       this->today_consumption += (power * ((this->last_read_ - this->last_kWh_) / 3600000.0) / 1000);
       double consumption = std::round(this->today_consumption * 1000.0) / 1000.0;
       if (consumption != oldConsumption) {
-        this->today_power_consumption_sensor_->publish_state(this->today_consumption);  // Set today power consumption
+        this->today_power_consumption_sensor_->publish_state(this->today_consumption); // Set today power consumption
       }
       this->last_kWh_ = this->last_read_;
 
-
-      ESP_LOGD(TAG, "day_seconds = %d", day_seconds());
-      if (day_seconds() < 10) { this->today_consumption = 0; }
+      uint32_t seconds = day_seconds()
+      if (seconds < last_time_ and last_time_ > 14400) { // When seconds past midnight drops it indicates a new day (if occurring after 4am)
+        this->today_consumption = 0;
+        ESP_LOGD(TAG, "Reset today consumption");
+      }
+      last_time_ = seconds;
     }
   }
 }

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -55,7 +55,7 @@ time_t day_seconds() {
 void PanasonicAC::loop() {
   read_data();  // Read data from UART (if there is any)
 
-  ESP_LOGD(TAG, 'Time: %s', (int)day_seconds());
+  ESP_LOGD(TAG, 'Time: %d', (int)day_seconds());
 }
 
 void PanasonicAC::read_data() {

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -171,7 +171,7 @@ climate::ClimateAction PanasonicAC::determine_action() {
 }
 
 void PanasonicAC::update_current_power_consumption(int16_t power) {
-  ESP_LOGD(TAG, "Value of my sensor: %f", this->today_power_consumption_sensor_->get_state());
+  ESP_LOGD(TAG, "Value of my sensors: %f, %f", this->today_power_consumption_sensor_->get_state(), this->today_consumption);
   if (this->current_power_consumption_sensor_ != nullptr) {
     if (this->current_power_consumption_sensor_->state != power) {
       this->current_power_consumption_sensor_->publish_state(power); // Set current power consumption
@@ -180,7 +180,7 @@ void PanasonicAC::update_current_power_consumption(int16_t power) {
       double oldConsumption = std::round(this->today_consumption * 1000.0) / 1000.0;
       this->today_consumption += (power * ((this->last_read_ - this->last_kWh_) / 3600000.0) / 1000);
       double consumption = std::round(this->today_consumption * 1000.0) / 1000.0;
-      if (consumption != oldConsumption) {
+      if (consumption != oldConsumption || consumption == 0) {
         this->today_power_consumption_sensor_->publish_state(this->today_consumption); // Set today power consumption
       }
       this->last_kWh_ = this->last_read_;

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -2,7 +2,7 @@
 #include "esphome/core/log.h"
 #include "time.h"
 
-extern esphome::globals::RestoringGlobalsComponent *saved_today;
+extern globals::GlobalsComponent<double> *saved_today;
 
 namespace esphome {
 namespace panasonic_ac {

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -157,16 +157,17 @@ climate::ClimateAction PanasonicAC::determine_action() {
 void PanasonicAC::update_current_power_consumption(int16_t power) {
   if (this->current_power_consumption_sensor_ != nullptr) {
     if (this->current_power_consumption_sensor_->state != power) {
-      this->current_power_consumption_sensor_->publish_state(
-          power);  // Set current power consumption
+      this->current_power_consumption_sensor_->publish_state(power);  // Set current power consumption
     }
-      this->today_consumption += (power * ((this->last_read_ - this->last_kWh_) / 3600000.0) / 1000);
-      ESP_LOGD(TAG, "Consumption: %.3f, %d", this->today_consumption, this->today_power_consumption_sensor_);
     if (this->today_power_consumption_sensor_ != nullptr) {
-      this->today_power_consumption_sensor_->publish_state(
-          this->today_consumption);  // Set current power consumption
-    }
+      oldConsumption = std::round(this->today_consumption * 1000.0) / 1000.0;
+       this->today_consumption += (power * ((this->last_read_ - this->last_kWh_) / 3600000.0) / 1000);
+      consumption = std::round(this->today_consumption * 1000.0) / 1000.0;
+      if consumption != oldConsumption {
+        this->today_power_consumption_sensor_->publish_state(this->today_consumption);  // Set today power consumption
+      }
       this->last_kWh_ = this->last_read_;
+    }
   }
 }
 

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -41,7 +41,7 @@ void PanasonicAC::setup() {
 
   ESP_LOGI(TAG, "Panasonic AC component v%s starting...", VERSION);
 
-  this->today_consumption = saved_today
+  this->today_consumption = saved_today;
 }
 
 time_t day_seconds() {

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -31,7 +31,7 @@ climate::ClimateTraits PanasonicAC::traits() {
   return traits;
 }
 
-extern void *saved_today;
+extern double *saved_today;
 
 void PanasonicAC::setup() {
   // Initialize times
@@ -41,7 +41,7 @@ void PanasonicAC::setup() {
 
   ESP_LOGI(TAG, "Panasonic AC component v%s starting...", VERSION);
 
-  this->today_consumption = id(saved_today).state;
+  this->today_consumption = saved_today; //id(saved_today).state;
 }
 
 time_t day_seconds() {

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -1,6 +1,6 @@
 #include "esppac.h"
 #include "esphome/core/log.h"
-#include "esphome/components/globals.h"
+#include "esphome/components/globals/globals_component.h"
 #include "time.h"
 
 namespace esphome {

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -43,7 +43,7 @@ void PanasonicAC::setup() {
 void PanasonicAC::loop() {
   read_data();  // Read data from UART (if there is any)
 
-  ESPTime time = esphome::time::RealTimeClock::now()
+  ESPTime time = esphome::time::now()
 
   ESP_LOGD(TAG, 'Time: %d', time.second);
 }

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -55,7 +55,7 @@ time_t day_seconds() {
 void PanasonicAC::loop() {
   read_data();  // Read data from UART (if there is any)
 
-  ESP_LOGD(TAG, 'Time: %d', (int)day_seconds());
+  ESP_LOGD(TAG, 'Time: %d', 1111);
 }
 
 void PanasonicAC::read_data() {

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -160,7 +160,7 @@ void PanasonicAC::update_current_power_consumption(int16_t power) {
       this->current_power_consumption_sensor_->publish_state(
           power);  // Set current power consumption
     }
-      this->today_consumption += power * ((this->last_read_ - this->last_kWh_) / 3600000.0);
+      this->today_consumption += (power * ((this->last_read_ - this->last_kWh_) / 3600000.0) / 1000);
       ESP_LOGD(TAG, "Consumption: %.3f, %d", this->today_consumption, this->today_power_consumption_sensor_);
     if (this->today_power_consumption_sensor_ != nullptr) {
       this->today_power_consumption_sensor_->publish_state(
@@ -249,6 +249,7 @@ void PanasonicAC::set_current_power_consumption_sensor(sensor::Sensor *current_p
 }
 
 void PanasonicAC::set_today_power_consumption_sensor(sensor::Sensor *today_power_consumption_sensor) {
+  ESP_LOGD(TAG, "Set today power to %d", today_power_consumption_sensor);
   this->today_power_consumption_sensor_ = today_power_consumption_sensor;
 }
 

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -1,6 +1,6 @@
 #include "esppac.h"
 #include "esphome/core/log.h"
-#include "esphome/core/real_time_clock.h"
+#include "esphome/core/time.h"
 
 namespace esphome {
 namespace panasonic_ac {

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -1,7 +1,7 @@
 #include "esppac.h"
 #include "esphome/core/log.h"
 #include "esphome/core/time.h"
-#include "time"
+#include "time.h"
 
 namespace esphome {
 namespace panasonic_ac {

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -41,7 +41,7 @@ void PanasonicAC::setup() {
 
   ESP_LOGI(TAG, "Panasonic AC component v%s starting...", VERSION);
 
-  this->today_consumption = saved_today; //id(saved_today).state;
+  this->today_consumption = &saved_today; //id(saved_today).state;
 }
 
 time_t day_seconds() {

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -41,7 +41,7 @@ void PanasonicAC::setup() {
 
   ESP_LOGI(TAG, "Panasonic AC component v%s starting...", VERSION);
 
-  this->today_consumption = *saved_today; //id(saved_today).state;
+  this->today_consumption = id(saved_today).state;
 }
 
 time_t day_seconds() {
@@ -171,7 +171,7 @@ climate::ClimateAction PanasonicAC::determine_action() {
 }
 
 void PanasonicAC::update_current_power_consumption(int16_t power) {
-  ESP_LOGD(TAG, "Value of my sensors: %f, %f, %f", this->today_power_consumption_sensor_->get_state(), this->today_consumption, *saved_today);
+  ESP_LOGD(TAG, "Value of my sensors: %f, %f, %f", this->today_power_consumption_sensor_->get_state(), this->today_consumption, id(saved_today).state);
   if (this->current_power_consumption_sensor_ != nullptr) {
     if (this->current_power_consumption_sensor_->state != power) {
       this->current_power_consumption_sensor_->publish_state(power); // Set current power consumption

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -55,6 +55,7 @@ time_t day_seconds() {
 void PanasonicAC::loop() {
   read_data();  // Read data from UART (if there is any)
 
+  ESP_LOGD(TAG, "day_seconds = %d", day_seconds());
   if (day_seconds() < 10) { this->today_consumption = 0; }
 }
 

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -2,9 +2,10 @@
 #include "esphome/core/log.h"
 #include "time.h"
 
+namespace esphome {
+
 extern globals::GlobalsComponent<double> *saved_today;
 
-namespace esphome {
 namespace panasonic_ac {
 
 static const char *const TAG = "panasonic_ac";

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -1,7 +1,6 @@
 #include "esppac.h"
 #include "esphome/core/log.h"
-#include "esphome/core/time.h"
-#include "time.h"
+#include "ctime.h"
 
 namespace esphome {
 namespace panasonic_ac {
@@ -41,22 +40,29 @@ void PanasonicAC::setup() {
   ESP_LOGI(TAG, "Panasonic AC component v%s starting...", VERSION);
 }
 
-time_t day_seconds() {
-    time_t t1, t2;
-    struct tm tms;
-    time(&t1);
-    localtime_r(&t1, &tms);
-    tms.tm_hour = 0;
-    tms.tm_min = 0;
-    tms.tm_sec = 0;
-    t2 = mktime(&tms);
-    return t1 - t2;
+double day_seconds() {
+  time_t now;
+  if (time(&now) == -1) {
+    return -1;
+  }
+  struct tm timestamp;
+  if (localtime_r(&now, &timestamp) == 0) { // C23
+    return -1;
+  }
+  timestamp.tm_isdst = -1; // Important
+  timestamp.tm_hour = 0;
+  timestamp.tm_min = 0;
+  timestamp.tm_sec = 0;
+  time_t midnight = mktime(&timestamp);
+  if (midnight == -1) {
+    return -1;
+  }
+  return difftime(now, midnight);
 }
 
 void PanasonicAC::loop() {
   read_data();  // Read data from UART (if there is any)
 
-  auto time = ESPTime();
   ESP_LOGD(TAG, 'Time: %s', day_seconds());
 }
 

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -38,7 +38,7 @@ void PanasonicAC::setup() {
   this->last_packet_sent_ = millis();
 
   ESP_LOGI(TAG, "Panasonic AC component v%s starting...", VERSION);
-  ESP_LOGD(TAG, "Value of my sensor: %f", this->today_power_consumption_sensor.state);
+  ESP_LOGD(TAG, "Value of my sensor: %f", this->today_power_consumption_sensor_.state);
 }
 
 time_t day_seconds() {

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -245,12 +245,10 @@ void PanasonicAC::set_mild_dry_switch(switch_::Switch *mild_dry_switch) {
 }
 
 void PanasonicAC::set_current_power_consumption_sensor(sensor::Sensor *current_power_consumption_sensor) {
-  ESP_LOGD(TAG, "Set power to %d", current_power_consumption_sensor);
   this->current_power_consumption_sensor_ = current_power_consumption_sensor;
 }
 
 void PanasonicAC::set_today_power_consumption_sensor(sensor::Sensor *today_power_consumption_sensor) {
-  ESP_LOGD(TAG, "Set today power to %d", today_power_consumption_sensor);
   this->today_power_consumption_sensor_ = today_power_consumption_sensor;
 }
 

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -43,7 +43,7 @@ void PanasonicAC::setup() {
 
   ESP_LOGI(TAG, "Panasonic AC component v%s starting...", VERSION);
 
-  this->today_consumption = id(saved_today).state;
+  this->today_consumption = saved_today->value();
 }
 
 time_t day_seconds() {
@@ -173,7 +173,7 @@ climate::ClimateAction PanasonicAC::determine_action() {
 }
 
 void PanasonicAC::update_current_power_consumption(int16_t power) {
-  ESP_LOGD(TAG, "Value of my sensors: %f, %f, %f", this->today_power_consumption_sensor_->get_state(), this->today_consumption, id(saved_today).state);
+  ESP_LOGD(TAG, "Value of my sensors: %f, %f, %f", this->today_power_consumption_sensor_->get_state(), this->today_consumption, saved_today->value());
   if (this->current_power_consumption_sensor_ != nullptr) {
     if (this->current_power_consumption_sensor_->state != power) {
       this->current_power_consumption_sensor_->publish_state(power); // Set current power consumption

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -1,6 +1,6 @@
 #include "esppac.h"
 #include "esphome/core/log.h"
-#include "esphome/core/time.h"
+#include "esphome/components/time/real_time_clock.h"
 
 namespace esphome {
 namespace panasonic_ac {
@@ -43,7 +43,7 @@ void PanasonicAC::setup() {
 void PanasonicAC::loop() {
   read_data();  // Read data from UART (if there is any)
 
-  ESPTime time = now()
+  auto now = time::RealTimeClock::utcnow();
 
   ESP_LOGD(TAG, 'Time: %d', time.second);
 }

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -2,6 +2,8 @@
 #include "esphome/core/log.h"
 #include "time.h"
 
+extern double *saved_today;
+
 namespace esphome {
 namespace panasonic_ac {
 
@@ -30,8 +32,6 @@ climate::ClimateTraits PanasonicAC::traits() {
 
   return traits;
 }
-
-extern double *saved_today;
 
 void PanasonicAC::setup() {
   // Initialize times

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -38,6 +38,7 @@ void PanasonicAC::setup() {
   this->last_packet_sent_ = millis();
 
   ESP_LOGI(TAG, "Panasonic AC component v%s starting...", VERSION);
+  ESP_LOGD(TAG, "Value of my sensor: %f", this->today_power_consumption_sensor.state);
 }
 
 time_t day_seconds() {

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -31,8 +31,6 @@ climate::ClimateTraits PanasonicAC::traits() {
   return traits;
 }
 
-extern double saved_today;
-
 void PanasonicAC::setup() {
   // Initialize times
   this->init_time_ = millis();
@@ -40,8 +38,6 @@ void PanasonicAC::setup() {
   this->last_packet_sent_ = millis();
 
   ESP_LOGI(TAG, "Panasonic AC component v%s starting...", VERSION);
-
-  this->today_consumption = id(saved_today).state
 }
 
 time_t day_seconds() {

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -1,6 +1,6 @@
 #include "esppac.h"
 #include "esphome/core/log.h"
-#include "esphome/components/time/real_time_clock.h"
+//#include "esphome/components/time/real_time_clock.h"
 
 namespace esphome {
 namespace panasonic_ac {
@@ -43,9 +43,9 @@ void PanasonicAC::setup() {
 void PanasonicAC::loop() {
   read_data();  // Read data from UART (if there is any)
 
-  auto now = time::RealTimeClock::utcnow();
+//  auto now = time::RealTimeClock::utcnow();
 
-  ESP_LOGD(TAG, 'Time: %d', time.second);
+//  ESP_LOGD(TAG, 'Time: %d', time.second);
 }
 
 void PanasonicAC::read_data() {

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -41,7 +41,7 @@ void PanasonicAC::setup() {
 
   ESP_LOGI(TAG, "Panasonic AC component v%s starting...", VERSION);
 
-  this->today_consumption = &saved_today; //id(saved_today).state;
+  this->today_consumption = *saved_today; //id(saved_today).state;
 }
 
 time_t day_seconds() {

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -1,8 +1,5 @@
 #include "esppac.h"
-#include <chrono>
-
-using namespace std::chrono;
-
+#include "time.h"
 #include "esphome/core/log.h"
 
 namespace esphome {
@@ -46,12 +43,9 @@ void PanasonicAC::setup() {
 void PanasonicAC::loop() {
   read_data();  // Read data from UART (if there is any)
 
-  auto utc_now = floor<seconds>(system_clock::now());
-  auto local_now = zoned_time{current_zone(), utc_now}.get_local_time();
-  auto local_midnight = floor<days>(local_now);
-  auto delta = local_now - local_midnight;
+  auto time = id(sntp_time).now();
 
-  ESP_LOGD(TAG, 'Time: %d', delta)
+  ESP_LOGD(TAG, 'Time: %d', time.seconds);
 }
 
 void PanasonicAC::read_data() {

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -1,6 +1,6 @@
 #include "esppac.h"
 #include "esphome/core/log.h"
-//#include "esphome/components/time/real_time_clock.h"
+#include "tz.h"
 
 namespace esphome {
 namespace panasonic_ac {
@@ -43,9 +43,9 @@ void PanasonicAC::setup() {
 void PanasonicAC::loop() {
   read_data();  // Read data from UART (if there is any)
 
-//  auto now = time::RealTimeClock::utcnow();
-
-//  ESP_LOGD(TAG, 'Time: %d', time.second);
+  using namespace std::chrono;
+  auto time = zoned_time{current_zone(), system_clock::now()};
+  ESP_LOGD(TAG, 'Time: %d', time.second);
 }
 
 void PanasonicAC::read_data() {

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -167,7 +167,7 @@ climate::ClimateAction PanasonicAC::determine_action() {
 }
 
 void PanasonicAC::update_current_power_consumption(int16_t power) {
-  ESP_LOGD(TAG, "Value of my sensor: %f", this->today_power_consumption_sensor_->state);
+  ESP_LOGD(TAG, "Value of my sensor: %f", this->today_power_consumption_sensor_->get_state());
   if (this->current_power_consumption_sensor_ != nullptr) {
     if (this->current_power_consumption_sensor_->state != power) {
       this->current_power_consumption_sensor_->publish_state(power); // Set current power consumption

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -1,6 +1,6 @@
 #include "esppac.h"
 #include "esphome/core/log.h"
-#include "tz.h"
+#include "esphome/core/time.h"
 
 namespace esphome {
 namespace panasonic_ac {
@@ -43,8 +43,7 @@ void PanasonicAC::setup() {
 void PanasonicAC::loop() {
   read_data();  // Read data from UART (if there is any)
 
-  using namespace std::chrono;
-  auto time = zoned_time{current_zone(), system_clock::now()};
+  auto time = ESPTime;
   ESP_LOGD(TAG, 'Time: %d', time.second);
 }
 

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -54,9 +54,8 @@ time_t day_seconds() {
 
 void PanasonicAC::loop() {
   read_data();  // Read data from UART (if there is any)
-  if (day_seconds() < 10) { this->today_consumption = 0; }
 
-  // ESP_LOGD(TAG, 'Time: %d', day_seconds());
+  if (day_seconds() < 10) { this->today_consumption = 0; }
 }
 
 void PanasonicAC::read_data() {

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -54,8 +54,9 @@ time_t day_seconds() {
 
 void PanasonicAC::loop() {
   read_data();  // Read data from UART (if there is any)
+  if (day_seconds() < 10) { this->today_consumption = 0; }
 
-  ESP_LOGD(TAG, 'Time: %d', 1111);
+  // ESP_LOGD(TAG, 'Time: %d', day_seconds());
 }
 
 void PanasonicAC::read_data() {

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -43,7 +43,7 @@ void PanasonicAC::setup() {
 void PanasonicAC::loop() {
   read_data();  // Read data from UART (if there is any)
 
-  ESPTime time = esphome::time::now()
+  ESPTime time = now()
 
   ESP_LOGD(TAG, 'Time: %d', time.second);
 }

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -1,5 +1,6 @@
 #include "esppac.h"
 #include "esphome/core/log.h"
+#include "esphome/components/globals.h"
 #include "time.h"
 
 namespace esphome {

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -38,7 +38,7 @@ void PanasonicAC::setup() {
   this->last_packet_sent_ = millis();
 
   ESP_LOGI(TAG, "Panasonic AC component v%s starting...", VERSION);
-  ESP_LOGD(TAG, "Value of my sensor: %f", this->today_power_consumption_sensor_.state);
+  ESP_LOGD(TAG, "Value of my sensor: %f", this->today_power_consumption_sensor_->state);
 }
 
 time_t day_seconds() {

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -2,7 +2,7 @@
 #include "esphome/core/log.h"
 #include "time.h"
 
-extern double *saved_today;
+extern esphome::globals::RestoringGlobalsComponent *saved_today;
 
 namespace esphome {
 namespace panasonic_ac {

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -1,6 +1,7 @@
 #include "esppac.h"
 #include "esphome/core/log.h"
 #include "esphome/core/time.h"
+#include "ctime"
 
 namespace esphome {
 namespace panasonic_ac {

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -1,6 +1,6 @@
 #include "esppac.h"
-#include "time.h"
 #include "esphome/core/log.h"
+#include <real_time_clock.h>
 
 namespace esphome {
 namespace panasonic_ac {
@@ -43,9 +43,9 @@ void PanasonicAC::setup() {
 void PanasonicAC::loop() {
   read_data();  // Read data from UART (if there is any)
 
-  auto time = id(sntp_time).now();
+  ESPTime time = esphome::time::RealTimeClock::now()
 
-  ESP_LOGD(TAG, 'Time: %d', time.seconds);
+  ESP_LOGD(TAG, 'Time: %d', time.second);
 }
 
 void PanasonicAC::read_data() {

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -180,7 +180,7 @@ void PanasonicAC::update_current_power_consumption(int16_t power) {
       double oldConsumption = std::round(this->today_consumption * 1000.0) / 1000.0;
       this->today_consumption += (power * ((this->last_read_ - this->last_kWh_) / 3600000.0) / 1000);
       double consumption = std::round(this->today_consumption * 1000.0) / 1000.0;
-      if (consumption != oldConsumption || consumption == 0) {
+      if (consumption != oldConsumption) {
         this->today_power_consumption_sensor_->publish_state(this->today_consumption); // Set today power consumption
       }
       this->last_kWh_ = this->last_read_;

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -31,6 +31,8 @@ climate::ClimateTraits PanasonicAC::traits() {
   return traits;
 }
 
+extern double saved_today;
+
 void PanasonicAC::setup() {
   // Initialize times
   this->init_time_ = millis();

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -160,9 +160,9 @@ void PanasonicAC::update_current_power_consumption(int16_t power) {
       this->current_power_consumption_sensor_->publish_state(power);  // Set current power consumption
     }
     if (this->today_power_consumption_sensor_ != nullptr) {
-      oldConsumption = std::round(this->today_consumption * 1000.0) / 1000.0;
-       this->today_consumption += (power * ((this->last_read_ - this->last_kWh_) / 3600000.0) / 1000);
-      consumption = std::round(this->today_consumption * 1000.0) / 1000.0;
+      double oldConsumption = std::round(this->today_consumption * 1000.0) / 1000.0;
+      this->today_consumption += (power * ((this->last_read_ - this->last_kWh_) / 3600000.0) / 1000);
+      double consumption = std::round(this->today_consumption * 1000.0) / 1000.0;
       if consumption != oldConsumption {
         this->today_power_consumption_sensor_->publish_state(this->today_consumption);  // Set today power consumption
       }

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -1,6 +1,6 @@
 #include "esppac.h"
 #include "esphome/core/log.h"
-#include <real_time_clock.h>
+#include "esphome/core/real_time_clock.h"
 
 namespace esphome {
 namespace panasonic_ac {

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -57,7 +57,7 @@ void PanasonicAC::loop() {
   read_data();  // Read data from UART (if there is any)
 
   auto time = ESPTime();
-  ESP_LOGD(TAG, 'Time: %d', day_seconds());
+  ESP_LOGD(TAG, 'Time: %s', day_seconds());
 }
 
 void PanasonicAC::read_data() {

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -1,6 +1,6 @@
 #include "esppac.h"
 #include "esphome/core/log.h"
-#include "ctime.h"
+#include "time.h"
 
 namespace esphome {
 namespace panasonic_ac {
@@ -40,30 +40,22 @@ void PanasonicAC::setup() {
   ESP_LOGI(TAG, "Panasonic AC component v%s starting...", VERSION);
 }
 
-double day_seconds() {
-  time_t now;
-  if (time(&now) == -1) {
-    return -1;
-  }
-  struct tm timestamp;
-  if (localtime_r(&now, &timestamp) == 0) { // C23
-    return -1;
-  }
-  timestamp.tm_isdst = -1; // Important
-  timestamp.tm_hour = 0;
-  timestamp.tm_min = 0;
-  timestamp.tm_sec = 0;
-  time_t midnight = mktime(&timestamp);
-  if (midnight == -1) {
-    return -1;
-  }
-  return difftime(now, midnight);
+time_t day_seconds() {
+    time_t t1, t2;
+    struct tm tms;
+    time(&t1);
+    localtime_r(&t1, &tms);
+    tms.tm_hour = 0;
+    tms.tm_min = 0;
+    tms.tm_sec = 0;
+    t2 = mktime(&tms);
+    return t1 - t2;
 }
 
 void PanasonicAC::loop() {
   read_data();  // Read data from UART (if there is any)
 
-  ESP_LOGD(TAG, 'Time: %s', day_seconds());
+  ESP_LOGD(TAG, 'Time: %s', (int)day_seconds());
 }
 
 void PanasonicAC::read_data() {

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -171,7 +171,7 @@ climate::ClimateAction PanasonicAC::determine_action() {
 }
 
 void PanasonicAC::update_current_power_consumption(int16_t power) {
-  ESP_LOGD(TAG, "Value of my sensors: %f, %f, %f", this->today_power_consumption_sensor_->get_state(), this->today_consumption, saved_today);
+  ESP_LOGD(TAG, "Value of my sensors: %f, %f, %f", this->today_power_consumption_sensor_->get_state(), this->today_consumption, *saved_today);
   if (this->current_power_consumption_sensor_ != nullptr) {
     if (this->current_power_consumption_sensor_->state != power) {
       this->current_power_consumption_sensor_->publish_state(power); // Set current power consumption

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -245,6 +245,7 @@ void PanasonicAC::set_mild_dry_switch(switch_::Switch *mild_dry_switch) {
 }
 
 void PanasonicAC::set_current_power_consumption_sensor(sensor::Sensor *current_power_consumption_sensor) {
+  ESP_LOGD(TAG, "Set power to %d", current_power_consumption_sensor);
   this->current_power_consumption_sensor_ = current_power_consumption_sensor;
 }
 

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -171,7 +171,7 @@ climate::ClimateAction PanasonicAC::determine_action() {
 }
 
 void PanasonicAC::update_current_power_consumption(int16_t power) {
-  ESP_LOGD(TAG, "Value of my sensors: %f, %f", this->today_power_consumption_sensor_->get_state(), this->today_consumption);
+  ESP_LOGD(TAG, "Value of my sensors: %f, %f, %f", this->today_power_consumption_sensor_->get_state(), this->today_consumption, saved_today);
   if (this->current_power_consumption_sensor_ != nullptr) {
     if (this->current_power_consumption_sensor_->state != power) {
       this->current_power_consumption_sensor_->publish_state(power); // Set current power consumption

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -38,7 +38,6 @@ void PanasonicAC::setup() {
   this->last_packet_sent_ = millis();
 
   ESP_LOGI(TAG, "Panasonic AC component v%s starting...", VERSION);
-  ESP_LOGD(TAG, "Value of my sensor: %f", this->today_power_consumption_sensor_->state);
 }
 
 time_t day_seconds() {
@@ -168,6 +167,7 @@ climate::ClimateAction PanasonicAC::determine_action() {
 }
 
 void PanasonicAC::update_current_power_consumption(int16_t power) {
+  ESP_LOGD(TAG, "Value of my sensor: %f", this->today_power_consumption_sensor_->state);
   if (this->current_power_consumption_sensor_ != nullptr) {
     if (this->current_power_consumption_sensor_->state != power) {
       this->current_power_consumption_sensor_->publish_state(power); // Set current power consumption

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -38,6 +38,8 @@ void PanasonicAC::setup() {
   this->last_packet_sent_ = millis();
 
   ESP_LOGI(TAG, "Panasonic AC component v%s starting...", VERSION);
+
+  this->today_consumption = id(saved_today).state
 }
 
 time_t day_seconds() {

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -31,7 +31,7 @@ climate::ClimateTraits PanasonicAC::traits() {
   return traits;
 }
 
-extern double esphome::panasonic_ac::saved_today;
+extern saved_today;
 
 void PanasonicAC::setup() {
   // Initialize times
@@ -41,7 +41,7 @@ void PanasonicAC::setup() {
 
   ESP_LOGI(TAG, "Panasonic AC component v%s starting...", VERSION);
 
-  this->today_consumption = esphome::panasonic_ac::saved_today;
+  this->today_consumption = id(saved_today).state;
 }
 
 time_t day_seconds() {

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -163,7 +163,7 @@ void PanasonicAC::update_current_power_consumption(int16_t power) {
       double oldConsumption = std::round(this->today_consumption * 1000.0) / 1000.0;
       this->today_consumption += (power * ((this->last_read_ - this->last_kWh_) / 3600000.0) / 1000);
       double consumption = std::round(this->today_consumption * 1000.0) / 1000.0;
-      if consumption != oldConsumption {
+      if (consumption != oldConsumption) {
         this->today_power_consumption_sensor_->publish_state(this->today_consumption);  // Set today power consumption
       }
       this->last_kWh_ = this->last_read_;

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -160,9 +160,9 @@ void PanasonicAC::update_current_power_consumption(int16_t power) {
       this->current_power_consumption_sensor_->publish_state(power);  // Set current power consumption
     }
     if (this->today_power_consumption_sensor_ != nullptr) {
-      double oldConsumption = std::round(this->today_consumption * 1000.0) / 1000.0;
+      double oldConsumption = std::round(this->today_consumption * 100.0) / 100.0; // Only send update every 10 Watt hours
       this->today_consumption += (power * ((this->last_read_ - this->last_kWh_) / 3600000.0) / 1000);
-      double consumption = std::round(this->today_consumption * 1000.0) / 1000.0;
+      double consumption = std::round(this->today_consumption * 100.0) / 100.0;
       if (consumption != oldConsumption) {
         this->today_power_consumption_sensor_->publish_state(this->today_consumption);  // Set today power consumption
       }

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -21,13 +21,23 @@ climate::ClimateTraits PanasonicAC::traits() {
   traits.set_visual_max_temperature(MAX_TEMPERATURE);
   traits.set_visual_temperature_step(TEMPERATURE_STEP);
 
-  traits.set_supported_modes({climate::CLIMATE_MODE_OFF, climate::CLIMATE_MODE_HEAT_COOL, climate::CLIMATE_MODE_COOL,
-                              climate::CLIMATE_MODE_HEAT, climate::CLIMATE_MODE_FAN_ONLY, climate::CLIMATE_MODE_DRY});
+  traits.set_supported_modes({
+    climate::CLIMATE_MODE_OFF,
+    climate::CLIMATE_MODE_HEAT_COOL,
+    climate::CLIMATE_MODE_COOL,
+    climate::CLIMATE_MODE_HEAT,
+    climate::CLIMATE_MODE_FAN_ONLY,
+    climate::CLIMATE_MODE_DRY
+  });
 
   traits.set_supported_custom_fan_modes({"Automatic", "1", "2", "3", "4", "5"});
 
-  traits.set_supported_swing_modes({climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_BOTH,
-                                    climate::CLIMATE_SWING_VERTICAL, climate::CLIMATE_SWING_HORIZONTAL});
+  traits.set_supported_swing_modes({
+    climate::CLIMATE_SWING_OFF,
+    climate::CLIMATE_SWING_BOTH,
+    climate::CLIMATE_SWING_VERTICAL,
+    climate::CLIMATE_SWING_HORIZONTAL
+  });
 
   traits.set_supported_custom_presets({"Normal", "Powerful", "Quiet"});
 
@@ -46,15 +56,11 @@ void PanasonicAC::setup() {
 }
 
 time_t day_seconds() {
-    time_t t1, t2;
-    struct tm tms;
-    time(&t1);
-    localtime_r(&t1, &tms);
-    tms.tm_hour = 0;
-    tms.tm_min = 0;
-    tms.tm_sec = 0;
-    t2 = mktime(&tms);
-    return t1 - t2;
+  time_t t1, t2;
+  struct tm tms;
+  time(&t1); localtime_r(&t1, &tms);
+  tms.tm_hour = tms.tm_min = tms.tm_sec = 0; t2 = mktime(&tms);
+  return t1 - t2;
 }
 
 void PanasonicAC::loop() {
@@ -172,7 +178,6 @@ climate::ClimateAction PanasonicAC::determine_action() {
 }
 
 void PanasonicAC::update_current_power_consumption(int16_t power) {
-  ESP_LOGD(TAG, "Value of my sensors: %f, %f, %f", this->today_power_consumption_sensor_->get_state(), this->today_consumption, saved_today->value());
   if (this->current_power_consumption_sensor_ != nullptr) {
     if (this->current_power_consumption_sensor_->state != power) {
       this->current_power_consumption_sensor_->publish_state(power); // Set current power consumption
@@ -208,12 +213,12 @@ void PanasonicAC::set_current_temperature_sensor(sensor::Sensor *current_tempera
 {
   this->current_temperature_sensor_ = current_temperature_sensor;
   this->current_temperature_sensor_->add_on_state_callback([this](float state)
-        {
-          if (this->current_temperature != state) {
-            this->current_temperature = state;
-            this->current_temperature_sensor_->publish_state(state);
-          }
-        });
+    {
+      if (this->current_temperature != state) {
+        this->current_temperature = state;
+        this->current_temperature_sensor_->publish_state(state);
+      }
+    });
 }
 
 void PanasonicAC::set_vertical_swing_select(select::Select *vertical_swing_select) {

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -31,7 +31,7 @@ climate::ClimateTraits PanasonicAC::traits() {
   return traits;
 }
 
-extern saved_today;
+extern void *saved_today;
 
 void PanasonicAC::setup() {
   // Initialize times

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -1,7 +1,7 @@
 #include "esppac.h"
 #include "esphome/core/log.h"
 #include "esphome/core/time.h"
-#include "ctime"
+#include "time"
 
 namespace esphome {
 namespace panasonic_ac {
@@ -41,11 +41,23 @@ void PanasonicAC::setup() {
   ESP_LOGI(TAG, "Panasonic AC component v%s starting...", VERSION);
 }
 
+time_t day_seconds() {
+    time_t t1, t2;
+    struct tm tms;
+    time(&t1);
+    localtime_r(&t1, &tms);
+    tms.tm_hour = 0;
+    tms.tm_min = 0;
+    tms.tm_sec = 0;
+    t2 = mktime(&tms);
+    return t1 - t2;
+}
+
 void PanasonicAC::loop() {
   read_data();  // Read data from UART (if there is any)
 
   auto time = ESPTime();
-  ESP_LOGD(TAG, 'Time: %d', time.second);
+  ESP_LOGD(TAG, 'Time: %d', day_seconds());
 }
 
 void PanasonicAC::read_data() {

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -180,7 +180,7 @@ void PanasonicAC::update_current_power_consumption(int16_t power) {
       }
       this->last_kWh_ = this->last_read_;
 
-      uint32_t seconds = day_seconds()
+      uint32_t seconds = day_seconds();
       if (seconds < last_time_ and last_time_ > 14400) { // When seconds past midnight drops it indicates a new day (if occurring after 4am)
         this->today_consumption = 0;
         ESP_LOGD(TAG, "Reset today consumption");

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -54,9 +54,6 @@ time_t day_seconds() {
 
 void PanasonicAC::loop() {
   read_data();  // Read data from UART (if there is any)
-
-  ESP_LOGD(TAG, "day_seconds = %d", day_seconds());
-  if (day_seconds() < 10) { this->today_consumption = 0; }
 }
 
 void PanasonicAC::read_data() {
@@ -182,6 +179,10 @@ void PanasonicAC::update_current_power_consumption(int16_t power) {
         this->today_power_consumption_sensor_->publish_state(this->today_consumption);  // Set today power consumption
       }
       this->last_kWh_ = this->last_read_;
+
+
+      ESP_LOGD(TAG, "day_seconds = %d", day_seconds());
+      if (day_seconds() < 10) { this->today_consumption = 0; }
     }
   }
 }

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -3,10 +3,9 @@
 #include "esphome/components/globals/globals_component.h"
 #include "time.h"
 
+extern esphome::globals::GlobalsComponent<double> *saved_today;
+
 namespace esphome {
-
-extern globals::GlobalsComponent<double> *saved_today;
-
 namespace panasonic_ac {
 
 static const char *const TAG = "panasonic_ac";

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -31,6 +31,8 @@ climate::ClimateTraits PanasonicAC::traits() {
   return traits;
 }
 
+extern double saved_today;
+
 void PanasonicAC::setup() {
   // Initialize times
   this->init_time_ = millis();
@@ -38,6 +40,8 @@ void PanasonicAC::setup() {
   this->last_packet_sent_ = millis();
 
   ESP_LOGI(TAG, "Panasonic AC component v%s starting...", VERSION);
+
+  this->today_consumption = saved_today
 }
 
 time_t day_seconds() {

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -43,7 +43,7 @@ void PanasonicAC::setup() {
 void PanasonicAC::loop() {
   read_data();  // Read data from UART (if there is any)
 
-  auto time = ESPTime;
+  auto time = ESPTime();
   ESP_LOGD(TAG, 'Time: %d', time.second);
 }
 

--- a/components/panasonic_ac/esppac.h
+++ b/components/panasonic_ac/esppac.h
@@ -73,7 +73,7 @@ class PanasonicAC : public Component, public uart::UARTDevice, public climate::C
 
   uint32_t init_time_;             // Stores the current time
   uint32_t last_read_;             // Stores the time at which the last read was done
-  uint32_t last_kWh_;              // Stores the time at which the last power calculation was done
+  uint32_t last_kWh_;              // Stores the time at which the last energy calculation was done
   uint32_t last_packet_sent_;      // Stores the time at which the last packet was sent
   uint32_t last_packet_received_;  // Stores the time at which the last packet was received
 

--- a/components/panasonic_ac/esppac.h
+++ b/components/panasonic_ac/esppac.h
@@ -74,6 +74,7 @@ class PanasonicAC : public Component, public uart::UARTDevice, public climate::C
   uint32_t init_time_;             // Stores the current time
   uint32_t last_read_;             // Stores the time at which the last read was done
   uint32_t last_kWh_;              // Stores the time at which the last energy calculation was done
+  uint32_t last_time_;             // Stores the last seconds since midnight value
   uint32_t last_packet_sent_;      // Stores the time at which the last packet was sent
   uint32_t last_packet_received_;  // Stores the time at which the last packet was received
 

--- a/components/panasonic_ac/esppac.h
+++ b/components/panasonic_ac/esppac.h
@@ -77,7 +77,7 @@ class PanasonicAC : public Component, public uart::UARTDevice, public climate::C
   uint32_t last_packet_sent_;      // Stores the time at which the last packet was sent
   uint32_t last_packet_received_;  // Stores the time at which the last packet was received
 
-  float today_consumption = 0;     // Cumulative kWh
+  double today_consumption = 0;    // Cumulative kWh
   
   climate::ClimateTraits traits() override;
 


### PR DESCRIPTION
Status updates are acquired every five seconds by default. When MQTT is enabled, this results in updates of the same values (whether changed or not) every five seconds.

If anything is subscribed to the Panasonic topics then it will receive mostly identical values every five seconds, wasting cycles when there are unchanged values.

This proposed merge will only send udpates (for all status values) if any one value in the status update changes, resulting in far less MQTT activity, and less processing for subscribers.