### PR TITLE
Add defrost sensor support for Panasonic AC

### DIFF
--- a/ac.yaml.example
+++ b/ac.yaml.example
@@ -44,6 +44,8 @@ climate:
       name: Panasonic AC Vertical Swing Mode
     outside_temperature:
       name: Panasonic AC Outside Temperature
+    defrost_sensor:
+      name: Panasonic AC Defrost Status
 
     # Enable as needed
     # eco_switch:

--- a/components/panasonic_ac/climate.py
+++ b/components/panasonic_ac/climate.py
@@ -7,9 +7,9 @@ from esphome.const import (
 )
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.components import uart, climate, sensor, select, switch
+from esphome.components import uart, climate, sensor, select, switch, binary_sensor
 
-AUTO_LOAD = ["switch", "sensor", "select"]
+AUTO_LOAD = ["switch", "sensor", "select", "binary_sensor"]
 DEPENDENCIES = ["uart"]
 
 panasonic_ac_ns = cg.esphome_ns.namespace("panasonic_ac")
@@ -40,6 +40,7 @@ CONF_ECO_SWITCH = "eco_switch"
 CONF_ECONAVI_SWITCH = "econavi_switch"
 CONF_MILD_DRY_SWITCH = "mild_dry_switch"
 CONF_CURRENT_POWER_CONSUMPTION = "current_power_consumption"
+CONF_DEFROST_SENSOR = "defrost_sensor"
 CONF_WLAN = "wlan"
 CONF_CNT = "cnt"
 
@@ -60,6 +61,7 @@ PANASONIC_COMMON_SCHEMA = {
         device_class=DEVICE_CLASS_TEMPERATURE,
         state_class=STATE_CLASS_MEASUREMENT,
     ),
+    cv.Optional(CONF_DEFROST_SENSOR): binary_sensor.binary_sensor_schema(),
     cv.Optional(CONF_NANOEX_SWITCH): SWITCH_SCHEMA,
     cv.Optional(CONF_OUTSIDE_TEMPERATURE_OFFSET): cv.int_range(min=-15, max=15),
 }
@@ -106,6 +108,10 @@ async def to_code(config):
     if CONF_OUTSIDE_TEMPERATURE in config:
         sens = await sensor.new_sensor(config[CONF_OUTSIDE_TEMPERATURE])
         cg.add(var.set_outside_temperature_sensor(sens))
+
+    if CONF_DEFROST_SENSOR in config:
+        sens = await binary_sensor.new_binary_sensor(config[CONF_DEFROST_SENSOR])
+        cg.add(var.set_defrost_sensor(sens))
 
     if CONF_OUTSIDE_TEMPERATURE_OFFSET in config:
         cg.add(var.set_outside_temperature_offset(config[CONF_OUTSIDE_TEMPERATURE_OFFSET]))

--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -177,6 +177,12 @@ void PanasonicAC::update_current_power_consumption(int16_t power) {
   }
 }
 
+void PanasonicAC::update_defrost(bool defrost) {
+  if (this->defrost_sensor_ != nullptr) {
+    this->defrost_sensor_->publish_state(defrost);
+  }
+}
+
 /*
  * Sensor handling
  */
@@ -270,6 +276,10 @@ void PanasonicAC::set_mild_dry_switch(switch_::Switch *mild_dry_switch) {
 
 void PanasonicAC::set_current_power_consumption_sensor(sensor::Sensor *current_power_consumption_sensor) {
   this->current_power_consumption_sensor_ = current_power_consumption_sensor;
+}
+
+void PanasonicAC::set_defrost_sensor(binary_sensor::BinarySensor *defrost_sensor) {
+  this->defrost_sensor_ = defrost_sensor;
 }
 
 /*

--- a/components/panasonic_ac/esppac.h
+++ b/components/panasonic_ac/esppac.h
@@ -4,6 +4,7 @@
 #include "esphome/components/select/select.h"
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/switch/switch.h"
+#include "esphome/components/binary_sensor/binary_sensor.h"
 #include "esphome/components/uart/uart.h"
 #include "esphome/core/component.h"
 
@@ -41,6 +42,7 @@ class PanasonicAC : public Component, public uart::UARTDevice, public climate::C
   void set_econavi_switch(switch_::Switch *econavi_switch);
   void set_mild_dry_switch(switch_::Switch *mild_dry_switch);
   void set_current_power_consumption_sensor(sensor::Sensor *current_power_consumption_sensor);
+  void set_defrost_sensor(binary_sensor::BinarySensor *defrost_sensor);
 
   void set_current_temperature_sensor(sensor::Sensor *current_temperature_sensor);
   void set_current_temperature_offset(int8_t current_temperature_offset);
@@ -58,6 +60,7 @@ class PanasonicAC : public Component, public uart::UARTDevice, public climate::C
   switch_::Switch *mild_dry_switch_ = nullptr;                  // Switch to toggle mild dry mode on/off
   sensor::Sensor *current_temperature_sensor_ = nullptr;        // Sensor to use for current temperature where AC does not report
   sensor::Sensor *current_power_consumption_sensor_ = nullptr;  // Sensor to store current power consumption from queries
+  binary_sensor::BinarySensor *defrost_sensor_ = nullptr;       // Sensor to store defrost status
 
   std::string vertical_swing_state_;
   std::string horizontal_swing_state_;
@@ -95,6 +98,7 @@ class PanasonicAC : public Component, public uart::UARTDevice, public climate::C
   void update_econavi(bool econavi);
   void update_mild_dry(bool mild_dry);
   void update_current_power_consumption(int16_t power);
+  void update_defrost(bool defrost);
 
   virtual void on_horizontal_swing_change(const std::string &swing) = 0;
   virtual void on_vertical_swing_change(const std::string &swing) = 0;

--- a/components/panasonic_ac/esppac_cnt.cpp
+++ b/components/panasonic_ac/esppac_cnt.cpp
@@ -353,6 +353,15 @@ void PanasonicACCNT::set_data(bool set) {
           (int8_t) this->rx_buffer_[28], (int8_t) this->rx_buffer_[29], (int8_t) this->rx_buffer_[30]);
       this->update_current_power_consumption(power_consumption);
     }
+
+    if (this->defrost_sensor_ != nullptr) {
+      if (this->rx_buffer_.size() >= 15) {
+        bool defrost = (this->rx_buffer_[14] == 0x02);
+        update_defrost(defrost);
+      } else {
+        ESP_LOGV(TAG, "Defrost status is not supported");
+      }
+    }
   }
 
   if (verticalSwing == "auto" && horizontalSwing == "auto")
@@ -475,11 +484,6 @@ void PanasonicACCNT::handle_packet() {
 
     this->set_data(true);
     this->publish_state();
-
-    if (this->rx_buffer_.size() >= 15) {
-      bool defrost = (this->rx_buffer_[14] == 0x02);
-      update_defrost(defrost);
-    }
 
     if (this->state_ != ACState::Ready)
       this->state_ = ACState::Ready;  // Mark as ready after first poll

--- a/components/panasonic_ac/esppac_cnt.cpp
+++ b/components/panasonic_ac/esppac_cnt.cpp
@@ -476,6 +476,11 @@ void PanasonicACCNT::handle_packet() {
     this->set_data(true);
     this->publish_state();
 
+    if (this->rx_buffer_.size() >= 15) {
+      bool defrost = (this->rx_buffer_[14] == 0x02);
+      update_defrost(defrost);
+    }
+
     if (this->state_ != ACState::Ready)
       this->state_ = ACState::Ready;  // Mark as ready after first poll
   } else {

--- a/components/panasonic_ac/esppac_wlan.cpp
+++ b/components/panasonic_ac/esppac_wlan.cpp
@@ -31,6 +31,14 @@ void PanasonicACWLAN::loop() {
   {
     log_packet(this->rx_buffer_);
 
+    // Check for defrost status packet
+    if (this->rx_buffer_[0] == 0x70 && this->rx_buffer_.size() >= 15) {
+      bool defrost = (this->rx_buffer_[14] == 0x02);
+      update_defrost(defrost);
+      this->rx_buffer_.clear();
+      return;
+    }
+
     if (!verify_packet())  // Verify length, header, counter and checksum
       return;
 


### PR DESCRIPTION
This PR adds a binary sensor to indicate when the unit is defrosting and exposes it in HA through the defrost sensor.