### PR TITLE
ESP Home 2026.4.4 compiling warnings fixed

### DIFF
--- a/components/panasonic_ac/esppac.cpp
+++ b/components/panasonic_ac/esppac.cpp
@@ -22,12 +22,8 @@ climate::ClimateTraits PanasonicAC::traits() {
   traits.set_supported_modes({climate::CLIMATE_MODE_OFF, climate::CLIMATE_MODE_HEAT_COOL, climate::CLIMATE_MODE_COOL,
                               climate::CLIMATE_MODE_HEAT, climate::CLIMATE_MODE_FAN_ONLY, climate::CLIMATE_MODE_DRY});
 
-  traits.set_supported_custom_fan_modes({"Automatic", "1", "2", "3", "4", "5"});
-
   traits.set_supported_swing_modes({climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_BOTH,
                                     climate::CLIMATE_SWING_VERTICAL, climate::CLIMATE_SWING_HORIZONTAL});
-
-  traits.set_supported_custom_presets({"Normal", "Powerful", "Quiet"});
 
   return traits;
 }
@@ -36,6 +32,9 @@ void PanasonicAC::setup() {
   // Initialize times
   this->init_time_ = millis();
   this->last_packet_sent_ = millis();
+
+  this->set_supported_custom_fan_modes({"Automatic", "1", "2", "3", "4", "5"});
+  this->set_supported_custom_presets({"Normal", "Powerful", "Quiet"});
 
   ESP_LOGI(TAG, "Panasonic AC component v%s starting...", VERSION);
 }


### PR DESCRIPTION
set_supported_custom_fan_modes and set_supported_custom_presets are moved from traits object to Climate-component(this).
Fixed these warnings:
```
Compiling .pioenvs/bedroom-ac/src/esphome/components/wifi/wifi_component_esp8266.cpp.o
src/esphome/components/panasonic_ac/esppac.cpp: In member function 'virtual esphome::climate::ClimateTraits esphome::panasonic_ac::PanasonicAC::traits()':
src/esphome/components/panasonic_ac/esppac.cpp:25:79: warning: 'void esphome::climate::ClimateTraits::set_supported_custom_fan_modes(std::initializer_list<const char*>)' is deprecated: Call set_supported_custom_fan_modes() on the Climate entity instead. Removed in 2026.11.0 [-Wdeprecated-declarations]
   25 |   traits.set_supported_custom_fan_modes({"Automatic", "1", "2", "3", "4", "5"});
      |                                                                               ^
In file included from src/esphome/components/climate/climate.h:11,
                 from src/esphome/components/panasonic_ac/esppac.h:3,
                 from src/esphome/components/panasonic_ac/esppac.cpp:1:
src/esphome/components/climate/climate_traits.h:163:8: note: declared here
  163 |   void set_supported_custom_fan_modes(std::initializer_list<const char *> modes) {
      |        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/esphome/components/panasonic_ac/esppac.cpp:30:70: warning: 'void esphome::climate::ClimateTraits::set_supported_custom_presets(std::initializer_list<const char*>)' is deprecated: Call set_supported_custom_presets() on the Climate entity instead. Removed in 2026.11.0 [-Wdeprecated-declarations]
   30 |   traits.set_supported_custom_presets({"Normal", "Powerful", "Quiet"});
      |                                                                      ^
In file included from src/esphome/components/climate/climate.h:11,
                 from src/esphome/components/panasonic_ac/esppac.h:3,
                 from src/esphome/components/panasonic_ac/esppac.cpp:1:
src/esphome/components/climate/climate_traits.h:202:8: note: declared here
  202 |   void set_supported_custom_presets(std::initializer_list<const char *> presets) {
      |        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
```