### PR TITLE
Add `hvac_action` support for CNT protocol

### DIFF
--- a/components/panasonic_ac/esppac_cnt.cpp
+++ b/components/panasonic_ac/esppac_cnt.cpp
@@ -382,6 +382,7 @@ void PanasonicACCNT::set_data(bool set) {
   this->update_eco(eco);
   this->update_econavi(econavi);
   this->update_mild_dry(mildDry);
+  this->action = this->determine_action();
 }
 
 /*


### PR DESCRIPTION

# Description

Currently, the `hvac_action` (current action) attribute is never set for the CNT protocol implementation (`esppac_cnt.cpp`). The `determine_action()` heuristic introduced in `esppac.cpp` (see #83, where it was established that the AC does not report a real hardware action signal, so `determine_action()` compares current vs. target temperature with a tolerance) is already wired up for the WLAN protocol in `esppac_wlan.cpp`, but was never connected for CNT — `this->action` is simply never assigned in `set_data()`.

As a result, `hvac_action` stays stuck at its default value (`off`), regardless of the actual HVAC mode, which breaks status displays that rely on this attribute (e.g. the Home Assistant climate card color, or dashboards like EspControl).

This PR adds a single line at the end of `set_data()` to reuse the existing `determine_action()` logic for CNT, bringing it to parity with WLAN:

```cpp
this->action = this->determine_action();
```

## Testing

Verified on real CN-CNT hardware (ESP32, Panasonic split unit) across all temperature-dependent branches:

- `COOL` mode → correctly reports `cooling`
- `HEAT` mode → correctly reports `heating`
- `OFF` mode → correctly reports `off`

Confirmed both via serial log (`Action: COOLING` / `Action: HEATING`) and directly via the Home Assistant entity attributes (`hvac_action`).

---

*This fix, along with the investigation into the root cause, was prepared with the assistance of Claude (Anthropic).*